### PR TITLE
Add new init job files

### DIFF
--- a/.github/workflows/deploy_gcp.yml
+++ b/.github/workflows/deploy_gcp.yml
@@ -103,7 +103,9 @@ jobs:
         sed -i "s/_GCP_PROJECT_ID_/"${{ secrets.GCP_PROJECT_ID }}"/g" overlays/dev/notification/kustomization.yaml  &&\
         sed -i "s/_GCP_PROJECT_ID_/"${{ secrets.GCP_PROJECT_ID }}"/g" overlays/dev/payexecution/kustomization.yaml  &&\
         sed -i "s/_GCP_PROJECT_ID_/"${{ secrets.GCP_PROJECT_ID }}"/g" overlays/dev/ranking/kustomization.yaml  &&\
-        sed -i "s/_GCP_PROJECT_ID_/"${{ secrets.GCP_PROJECT_ID }}"/g" overlays/dev/searchitem/kustomization.yaml
+        sed -i "s/_GCP_PROJECT_ID_/"${{ secrets.GCP_PROJECT_ID }}"/g" overlays/dev/searchitem/kustomization.yaml &&\
+        sed -i "s/_GCP_PROJECT_ID_/"${{ secrets.GCP_PROJECT_ID }}"/g" overlays/dev/init-job/kustomization.yaml &&\
+        sed -i "s/_GDRIVE_URL_/"${{ secrets._GDRIVE_URL_ }}"/g" base/init-job/job.yaml
 
     - name: deploy
       run: kubectl apply -k overlays/dev/

--- a/kustomize/base/init-job/job.yaml
+++ b/kustomize/base/init-job/job.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: initial-mockten-job
+spec:
+  template:
+    spec:
+      containers:
+      - name: copy-init-files
+        image: gcr.io/go-portforio/static-file
+        command: ["/bin/sh", "-c", "/work/run.sh"]
+        args: ["_GDRIVE_URL_"]
+        volumeMounts:
+        - name: mockten-static-disk
+          mountPath: "/mnt/disk"
+      restartPolicy: Never
+      volumes:
+      - name: mockten-static-disk
+        persistentVolumeClaim:
+          claimName:  ecfront-pvc

--- a/kustomize/base/init-job/kustomization.yaml
+++ b/kustomize/base/init-job/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: init
+
+resources:
+- job.yaml

--- a/kustomize/overlays/dev/init-job/README.md
+++ b/kustomize/overlays/dev/init-job/README.md
@@ -1,0 +1,3 @@
+# initial job
+
+for creating initial mysql data.

--- a/kustomize/overlays/dev/init-job/kustomization.yaml
+++ b/kustomize/overlays/dev/init-job/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: dev-mockten
+namePrefix: dev-
+
+images:
+- name: gcr.io/go-portforio/static-file
+  newname: gcr.io/_GCP_PROJECT_ID_/static-file
+  newTag: v0.0.1
+
+resources:
+- ../../../base/init-job


### PR DESCRIPTION
## Overview
write requests for mockten's deployment. 
- New files which are job for K8s. Those files download ecfront static files from Google Drive and push GCP instance's disk so that ecfront container get those files from Persistent Volume disk.

## Operation Check
- None so far.